### PR TITLE
Fix `bake` calls.

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -178,7 +178,7 @@ bake_in () { baking_dir=$1; }
 bake_as () { baking_user=$1; }
 bake () {
   this_cmd=
-  [ -n "$baking_dir" ] && this_cmd="$cmd cd $baking_dir &&"
+  [ -n "$baking_dir" ] && this_cmd="cd $baking_dir &&"
   [ -n "$baking_user" ] && this_cmd="$this_cmd sudo -u $baking_user sh -c '"
   this_cmd="$this_cmd$1"
   [ -n "$baking_user" ] && this_cmd="$this_cmd'"


### PR DESCRIPTION
I believe the inclusion of `$cmd` here was not intended. It causes a failure
case where calls to `bake ()` include some commands twice or includes an
unintentional command. E.g.:

``` shell
missing: github jnwhiteh/vim-golang
command git cd /Users/amerine/code/amerine/dotfiles/vim/bundle &&mkdir -p /Users/amerine/code/amerine/dotfiles/vim/bundle/vim-golang
git: 'cd' is not a git command. See 'git --help'.

Did you mean this?
  co
failed with status: 1
```

With this change it works:

``` shell
checking status: github jnwhiteh/vim-golang
missing: github jnwhiteh/vim-golang
cd /Users/amerine/code/amerine/dotfiles/vim/bundle &&mkdir -p /Users/amerine/code/amerine/dotfiles/vim/bundle/vim-golang
cd /Users/amerine/code/amerine/dotfiles/vim/bundle &&command git clone https://github.com/jnwhiteh/vim-golang.git /Users/amerine/code/amerine/dotfiles/vim/bundle/vim-golang
Cloning into '/Users/amerine/code/amerine/dotfiles/vim/bundle/vim-golang'...
remote: Reusing existing pack: 347, done.
remote: Total 347 (delta 0), reused 0 (delta 0)
Receiving objects: 100% (347/347), 72.36 KiB | 0 bytes/s, done.
Resolving deltas: 100% (101/101), done.
Checking connectivity... done.
success: github jnwhiteh/vim-golang
```

I'm not sure how to write a test to ensure the functionality is correct.
