### PR TITLE
iptables assertion type

### DIFF
--- a/core/iptables.sh
+++ b/core/iptables.sh
@@ -5,8 +5,8 @@ case $action in
   status)
     out=$(bake sudo iptables -C $* 2>&1)
     status=$?
-    [ "$status" -gt 0 ] && return 10
-    return 0 ;;
+    [ "$status" -gt 0 ] && return $STATUS_MISSING
+    return $STATUS_OK ;;
   install)
     bake sudo iptables -A $*
     ;;

--- a/test/assert-iptables.bats
+++ b/test/assert-iptables.bats
@@ -4,16 +4,16 @@
 
 iptables () { . $BORK_SOURCE_DIR/core/iptables.sh $*; }
 
-@test "iptables status: returns 10 when rule is missing" {
+@test "iptables status: returns MISSING when rule is missing" {
   respond_to "sudo iptables -C INPUT -i lo -j ACCEPT" \
     "echo 'iptables: Bad rule (does a matching rule exist in that chain?).' >&2; return 1"
   run iptables status "INPUT -i lo -j ACCEPT"
-  [ "$status" -eq 10 ]
+  [ "$status" -eq $STATUS_MISSING ]
 }
 
-@test "iptables status: returns 0 when rule is present" {
+@test "iptables status: returns OK when rule is present" {
   run iptables status "INPUT -i lo -j ACCEPT"
-  [ "$status" -eq 0 ]
+  [ "$status" -eq $STATUS_OK ]
 }
 
 @test "iptables install: bakes the -A command" {


### PR DESCRIPTION
It's _really_ naive for now, but I'm not sure how to improve it in a simple manner.  Possibly:

``` bash
ok iptables \
  "INPUT -i lo -j ACCEPT" \
  "INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT" \
  "INPUT -p tcp --dport 80 -j ACCEPT" \
  "INPUT -p tcp --dport 443 -j ACCEPT" \
  "INPUT -p tcp --dport 22 -j ACCEPT" \
  "INPUT -j DROP"
```

where it'd check each rule in order, and verify that it occurred after the previous one. This would allow for unspecified rules to still exist (f.e., fail2ban) and yet still validate the rules we want.

What I'm doing now is basically:

``` bash
ok iptables "INPUT -i lo -j ACCEPT"
ok iptables "INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT"
ok iptables "INPUT -p tcp --dport 80 -j ACCEPT"
ok iptables "INPUT -p tcp --dport 443 -j ACCEPT"
ok iptables "INPUT -p tcp --dport 22 -j ACCEPT"
ok iptables "INPUT -j DROP"
```

but there's no way to assert, for example that the final DROP happens at the end of the chain.  If I were to somehow add a concept of state to the assertion types (I want/need caching anyway), then the iptables type could assert that any new rules in a chain come after previous rules in that same chain.  But I don't have any state for the type assertion functions yet.
