### PR TITLE
Use new homebrew curl location

### DIFF
--- a/types/brew.sh
+++ b/types/brew.sh
@@ -26,7 +26,7 @@ if [ -z "$name" ]; then
       ;;
 
     install)
-      bake 'ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/homebrew/master/install)"'
+      bake 'ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"'
       ;;
 
     upgrade)


### PR DESCRIPTION
missing: brew
Whoops, the Homebrew installer has moved! Please instead run:

ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"

Also, please ask wherever you got this link from to update it to the above.
Thanks!
verifying : brew
-  failed
