### PR TITLE
types/cash.sh #status was raising $STATUS_UNSUPPORTED_PLATFORM.

### DIFF
--- a/test/type-cask.bats
+++ b/test/type-cask.bats
@@ -6,7 +6,6 @@ cask () { . $BORK_SOURCE_DIR/types/cask.sh $*; }
 setup () {
   respond_to "uname -s" "echo Darwin"
   respond_to "which brew" "echo /usr/local/bin/brew"
-  respond_to "brew cask" "return 0"
   respond_to "brew cask list" "cat $fixtures/cask-list.txt"
 }
 

--- a/test/type-cask.bats
+++ b/test/type-cask.bats
@@ -6,7 +6,7 @@ cask () { . $BORK_SOURCE_DIR/types/cask.sh $*; }
 setup () {
   respond_to "uname -s" "echo Darwin"
   respond_to "which brew" "echo /usr/local/bin/brew"
-  respond_to "brew cask 2" "return 0"
+  respond_to "brew cask" "return 0"
   respond_to "brew cask list" "cat $fixtures/cask-list.txt"
 }
 
@@ -22,8 +22,18 @@ setup () {
   [ "$status" -eq $STATUS_FAILED_PRECONDITION ]
 }
 
+@test "brew cask 2 returns > 0 always" {
+  run brew cask 2
+  [ "$status" -gt 0 ]
+}
+
+@test "brew cask returns 0" {
+  run brew cask
+  [ "$status" -eq 0 ]
+}
+
 @test "cask status reports missing cask package" {
-  respond_to "brew cask 2" "return 1"
+  respond_to "brew cask" "return 1"
   run cask status something
   [ "$status" -eq $STATUS_FAILED_PRECONDITION ]
 }
@@ -43,4 +53,9 @@ setup () {
   [ "$status" -eq 0 ]
   run baked_output
   [ "$output" = 'brew cask install missing_package' ]
+}
+
+@test "action not found returns 1" {
+  run cask something something
+  [ "$status" -eq 1 ]
 }

--- a/types/cask.sh
+++ b/types/cask.sh
@@ -13,7 +13,7 @@ case $action in
   status)
     baking_platform_is "Darwin" || return $STATUS_UNSUPPORTED_PLATFORM
     needs_exec "brew" || return $STATUS_FAILED_PRECONDITION
-    bake brew cask 2&>/dev/null
+    bake brew cask &> /dev/null
     [ "$?" -gt 0 ] && return $STATUS_FAILED_PRECONDITION
 
     list=$(bake brew cask list)
@@ -21,8 +21,8 @@ case $action in
     [ "$?" -gt 0 ] && return $STATUS_MISSING
     return 0 ;;
 
-  install) 
-    if [ -n "$appdir"  ]; then
+  install)
+    if [ -n "$appdir" ]; then
       bake brew cask install $name --appdir=$appdir
     else
       bake brew cask install $name


### PR DESCRIPTION
The error was on `brew cask 2`, returning -gt 0 every time. 
I noticed the failure when trying to `ok cask something`.
