### PR TITLE
download type, with http wrapper & tests

### DIFF
--- a/lib/helpers/http.sh
+++ b/lib/helpers/http.sh
@@ -1,0 +1,33 @@
+has_curl () {
+    needs_exec "curl"
+}
+
+http_head () {
+    url=$1
+    shift 1
+    has_curl
+    if [ "$?" -eq 0 ]; then
+        echo "curl -sI \"$url\""
+    else
+        echo "curl not found; wget support not implemented yet"
+        return 1
+    fi
+}
+
+http_header () {
+    header=$1
+    headers=$2
+    echo "$headers" | grep "$header" | tr -s ' ' | cut -d' ' -f2
+}
+
+http_get () {
+    url=$1
+    target=$2
+    has_curl
+    if [ "$?" -eq 0 ]; then
+        echo "curl -so $target \"$url\" &> /dev/null"
+    else
+        echo "curl not found; wget support not implemented yet"
+        return 1
+    fi
+}

--- a/lib/helpers/http.sh
+++ b/lib/helpers/http.sh
@@ -2,7 +2,7 @@ has_curl () {
     needs_exec "curl"
 }
 
-http_head () {
+http_head_cmd () {
     url=$1
     shift 1
     has_curl
@@ -20,7 +20,7 @@ http_header () {
     echo "$headers" | grep "$header" | tr -s ' ' | cut -d' ' -f2
 }
 
-http_get () {
+http_get_cmd () {
     url=$1
     target=$2
     has_curl

--- a/test/fixtures/http-head-curl.txt
+++ b/test/fixtures/http-head-curl.txt
@@ -1,3 +1,5 @@
-200 OK
-
-Content-Length 312
+HTTP/1.1 200 OK
+Location: http://foo.com/bar.txt
+Content-Type: text/plain; charset=UTF-8
+Date: Tue, 22 Mar 2016 04:04:05 GMT
+Content-Length: 312

--- a/test/fixtures/http-head-curl.txt
+++ b/test/fixtures/http-head-curl.txt
@@ -1,0 +1,3 @@
+200 OK
+
+Content-Length 312

--- a/test/help-http.bats
+++ b/test/help-http.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+. test/helpers.sh
+
+@test "with curl and head performs a head request" {
+    respond_to "which curl" "echo /usr/bin/curl"
+    url="https://foo.com"
+    respond_to "curl -sI \"https://foo.com\"" "cat $fixtures/http-head-curl.txt"
+    run http_head "$url"
+    [ "$status" -eq 0 ]
+    [ 'curl -sI "https://foo.com"' = $output ]
+}
+
+@test "extracting a header value" {
+    input=$(cat "$fixtures/http-head-curl.txt")
+    run http_header "Content-Length" "$input"
+    [ "312" -eq $output ]
+}
+
+@test "getting a file" {
+    url="https://foo.com/bar"
+    target="/boo/baz"
+    run http_get "$url" "$target"
+    [ "$status" -eq 0 ]
+    p $output
+    [ "curl -so $target \"$url\" &> /dev/null" = $output ]
+}

--- a/test/help-http.bats
+++ b/test/help-http.bats
@@ -6,7 +6,7 @@
     respond_to "which curl" "echo /usr/bin/curl"
     url="https://foo.com"
     respond_to "curl -sI \"https://foo.com\"" "cat $fixtures/http-head-curl.txt"
-    run http_head "$url"
+    run http_head_cmd "$url"
     [ "$status" -eq 0 ]
     [ 'curl -sI "https://foo.com"' = $output ]
 }
@@ -20,8 +20,7 @@
 @test "getting a file" {
     url="https://foo.com/bar"
     target="/boo/baz"
-    run http_get "$url" "$target"
+    run http_get_cmd "$url" "$target"
     [ "$status" -eq 0 ]
-    p $output
     [ "curl -so $target \"$url\" &> /dev/null" = $output ]
 }

--- a/test/type-download.bats
+++ b/test/type-download.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+. test/helpers.sh
+
+download () { . $BORK_SOURCE_DIR/types/download.sh $*; }
+
+@test "download status: when file is MISSING" {
+    respond_to "[ -f missing ]" "return 1"
+    run download status missing "http://foo.com"
+    [ "$status" -eq $STATUS_MISSING ]
+}
+
+@test "download status: without comparisons returns OK when file exists" {
+    target="foo/bar.txt"
+    respond_to "curl -sI \"http://foo.com/bar.txt\"" "return 1"
+    run download status "$target" "http://foo.com/bar.txt"
+    [ "$status" -eq $STATUS_OK ]
+}
+
+@test "download status: returns CONFLICT_UPGRADE when comparing size and it doesn't match" {
+    target="foo/bar.txt"
+    respond_to "ls -al foo/bar.txt" \
+               "echo '-rw-r--r--   1 mattly  staff  11091 Mar 21 12:55 bar.txt'"
+    respond_to "curl -sI \"http://foo.com/bar.txt\"" "cat $fixtures/http-head-curl.txt"
+    run download status "$target" "http://foo.com/bar.txt" --size
+    [ "$status" -eq $STATUS_CONFLICT_UPGRADE ]
+    [ "${#lines[*]}" -eq 2 ]
+}
+
+@test "download status: returns OK when conditions match" {
+    target="foo/bar.txt"
+    respond_to "ls -al foo/bar.txt" \
+               "echo '-rw-r--r--   1 mattly  staff    312 Mar 21 12:55 bar.txt'"
+    respond_to "curl -sI \"http://foo.com/bar.txt\"" "cat $fixtures/http-head-curl.txt"
+    run download status "$target" "http://foo.com/bar.txt" --size
+    [ "$status" -eq $STATUS_OK ]
+}
+
+@test "download install: gets from remote" {
+    target="foo/bar.txt"
+    run download install "$target" "http://foo.com/bar.txt"
+    [ "$status" -eq $STATUS_OK ]
+    run baked_output
+    expected="curl -so $target \"http://foo.com/bar.txt\" &> /dev/null"
+    [[ "${lines[1]}" = $expected ]]
+}

--- a/types/brew.sh
+++ b/types/brew.sh
@@ -1,5 +1,4 @@
-# TODO:
-# - write tests for the packageless 'brew' assertion
+# TODO write tests for the packageless 'brew' assertion
 
 action=$1
 name=$2

--- a/types/download.sh
+++ b/types/download.sh
@@ -1,0 +1,36 @@
+action=$1
+targetfile=$2
+sourceurl=$3
+shift 3
+
+case "$action" in
+    desc)
+        echo "assert the presence & comparisons of a file to a URL"
+        echo "> download ~/file.zip \"http://example.com/file.zip\""
+        echo "--size                (compare size to Content-Length at URL)"
+        ;;
+
+    status)
+        bake [ -f $targetfile ] || return $STATUS_MISSING
+
+        if $(arguments get size); then
+            fileinfo=$(bake ls -al "$targetfile")
+            sourcesize=$(echo "$fileinfo" | tr -s ' ' | cut -d' ' -f5)
+            remoteinfo=$(bake $(http_head_cmd "$sourceurl"))
+            remotesize=$(http_header "Content-Length" "$remoteinfo")
+            remotesize=${remotesize%%[^0-9]*}
+            if [ "$sourcesize" != "$remotesize" ]; then
+                echo "expected size: $sourcesize bytes"
+                echo "received size: $remotesize bytes"
+                return $STATUS_CONFLICT_UPGRADE
+            fi
+        fi
+        return $STATUS_OK
+    ;;
+
+    install|upgrade)
+        bake $(http_get_cmd $sourceurl $targetfile)
+    ;;
+
+    *) return 1 ;;
+esac


### PR DESCRIPTION
This replaces #47 as a test against a local file that would be downloaded from a url. Assuming the url is http/s, you can compare the local size against the Content-Length header as well.

I added some indirection around curl the same way there is around md5 -- debian seems to ship with wget instead. the http wrapper doesn't yet support wget but this shouldn't be too hard to add.