### PR TITLE
Quote filenames properly for download type

### DIFF
--- a/lib/declarations/ok.sh
+++ b/lib/declarations/ok.sh
@@ -122,7 +122,7 @@ ok () {
       esac
       if did_update; then
         echo "verifying $last_change_type: $assertion $argstr"
-        output=$(eval "_ok_run $fn status $quoted_argstr")
+        output=$(eval "$(_source_runner $fn) status $quoted_argstr")
         status=$?
         if [ "$status" -gt 0 ]; then
           echo "* $last_change_type failed"

--- a/lib/helpers/bake.sh
+++ b/lib/helpers/bake.sh
@@ -1,1 +1,3 @@
-bake () { eval "$*"; }
+bake () {
+    echo "$*" >> DEBUG
+    eval "$*"; }

--- a/lib/helpers/bake.sh
+++ b/lib/helpers/bake.sh
@@ -1,3 +1,1 @@
-bake () {
-    echo "$*" >> DEBUG
-    eval "$*"; }
+bake () { eval "$*"; }

--- a/lib/helpers/http.sh
+++ b/lib/helpers/http.sh
@@ -25,7 +25,7 @@ http_get_cmd () {
     target=$2
     has_curl
     if [ "$?" -eq 0 ]; then
-        echo "curl -so $target \"$url\" &> /dev/null"
+        echo "curl -so \"$target\" \"$url\" &> /dev/null"
     else
         echo "curl not found; wget support not implemented yet"
         return 1

--- a/test/help-http.bats
+++ b/test/help-http.bats
@@ -2,7 +2,7 @@
 
 . test/helpers.sh
 
-@test "with curl and head performs a head request" {
+@test "http_head_cmd: with curl performs a head request" {
     respond_to "which curl" "echo /usr/bin/curl"
     url="https://foo.com"
     respond_to "curl -sI \"https://foo.com\"" "cat $fixtures/http-head-curl.txt"
@@ -11,16 +11,16 @@
     [ 'curl -sI "https://foo.com"' = $output ]
 }
 
-@test "extracting a header value" {
+@test "http_header: extracting a header value" {
     input=$(cat "$fixtures/http-head-curl.txt")
     run http_header "Content-Length" "$input"
     [ "312" -eq $output ]
 }
 
-@test "getting a file" {
+@test "htpp_get: getting a file" {
     url="https://foo.com/bar"
     target="/boo/baz"
     run http_get_cmd "$url" "$target"
     [ "$status" -eq 0 ]
-    [ "curl -so $target \"$url\" &> /dev/null" = $output ]
+    [ "curl -so \"$target\" \"$url\" &> /dev/null" = $output ]
 }

--- a/test/type-download.bats
+++ b/test/type-download.bats
@@ -5,7 +5,7 @@
 download () { . $BORK_SOURCE_DIR/types/download.sh $*; }
 
 @test "download status: when file is MISSING" {
-    respond_to "[ -f missing ]" "return 1"
+    respond_to "[ -f \"missing\" ]" "return 1"
     run download status missing "http://foo.com"
     [ "$status" -eq $STATUS_MISSING ]
 }
@@ -19,7 +19,7 @@ download () { . $BORK_SOURCE_DIR/types/download.sh $*; }
 
 @test "download status: returns CONFLICT_UPGRADE when comparing size and it doesn't match" {
     target="foo/bar.txt"
-    respond_to "ls -al foo/bar.txt" \
+    respond_to "ls -al \"foo/bar.txt\"" \
                "echo '-rw-r--r--   1 mattly  staff  11091 Mar 21 12:55 bar.txt'"
     respond_to "curl -sI \"http://foo.com/bar.txt\"" "cat $fixtures/http-head-curl.txt"
     run download status "$target" "http://foo.com/bar.txt" --size
@@ -29,7 +29,7 @@ download () { . $BORK_SOURCE_DIR/types/download.sh $*; }
 
 @test "download status: returns OK when conditions match" {
     target="foo/bar.txt"
-    respond_to "ls -al foo/bar.txt" \
+    respond_to "ls -al \"foo/bar.txt\"" \
                "echo '-rw-r--r--   1 mattly  staff    312 Mar 21 12:55 bar.txt'"
     respond_to "curl -sI \"http://foo.com/bar.txt\"" "cat $fixtures/http-head-curl.txt"
     run download status "$target" "http://foo.com/bar.txt" --size
@@ -41,6 +41,6 @@ download () { . $BORK_SOURCE_DIR/types/download.sh $*; }
     run download install "$target" "http://foo.com/bar.txt"
     [ "$status" -eq $STATUS_OK ]
     run baked_output
-    expected="curl -so $target \"http://foo.com/bar.txt\" &> /dev/null"
+    expected="curl -so \"$target\" \"http://foo.com/bar.txt\" &> /dev/null"
     [[ "${lines[1]}" = $expected ]]
 }

--- a/types/download.sh
+++ b/types/download.sh
@@ -11,17 +11,17 @@ case "$action" in
         ;;
 
     status)
-        bake [ -f $targetfile ] || return $STATUS_MISSING
+        bake [ -f "\"$targetfile\"" ] || return $STATUS_MISSING
 
         if $(arguments get size); then
-            fileinfo=$(bake ls -al "$targetfile")
+            fileinfo=$(bake ls -al "\"$targetfile\"")
             sourcesize=$(echo "$fileinfo" | tr -s ' ' | cut -d' ' -f5)
             remoteinfo=$(bake $(http_head_cmd "$sourceurl"))
             remotesize=$(http_header "Content-Length" "$remoteinfo")
             remotesize=${remotesize%%[^0-9]*}
             if [ "$sourcesize" != "$remotesize" ]; then
-                echo "expected size: $sourcesize bytes"
-                echo "received size: $remotesize bytes"
+                echo "expected size: $remotesize bytes"
+                echo "received size: $localsize bytes"
                 return $STATUS_CONFLICT_UPGRADE
             fi
         fi
@@ -29,7 +29,7 @@ case "$action" in
     ;;
 
     install|upgrade)
-        bake $(http_get_cmd $sourceurl $targetfile)
+        bake $(http_get_cmd "$sourceurl" "$targetfile")
     ;;
 
     *) return 1 ;;


### PR DESCRIPTION
Fixes a problem found by @frdmn where handing files with spaces in the name wasn't working.

I had to change `ok` to re-validate the same way it performs initial validation, instead of running the whole harness... I'm not entirely sure why, but it wasn't working quite as well. This is probably for the best overall.