### PR TITLE
Explicit git destinations

### DIFF
--- a/test/type-github.bats
+++ b/test/type-github.bats
@@ -4,16 +4,32 @@
 . bin/bork-compile > /dev/null
 github () { . $BORK_SOURCE_DIR/types/github.sh $*; }
 
+intercept_git () { echo "$*"; }
+git_call="intercept_git"
+
+@test "github status: handles implicit target" {
+  run github status mattly/bork
+  [ "$output" = "status https://github.com/mattly/bork.git" ]
+}
+
+@test "github status: handles explicit target" {
+  run github status /Users/mattly/code/bork mattly/bork
+  [ "$output" = "status /Users/mattly/code/bork https://github.com/mattly/bork.git" ]
+}
+
+@test "github status: handles --ssh argument" {
+  run github status mattly/bork --ssh
+  [ "$output" = "status git@github.com:mattly/bork.git" ]
+}
+
 @test "github compile: outputs git type via include_assertion" {
   operation="compile"
-  git=$(include_assertion git $BORK_SOURCE_DIR/types/git.sh)
+  gitfn=$(include_assertion git $BORK_SOURCE_DIR/types/git.sh)
   bag init compiled_types
   run github compile foo/bar
   [ "$status" -eq 0 ]
   n=0
-  for line in $git; do
-    p "expected: $line"
-    p "received: ${lines[n]}"
+  for line in $gitfn; do
     [ "${lines[n]}" = $line ]
     n=$(( n + 1 ))
   done

--- a/types/git.sh
+++ b/types/git.sh
@@ -10,7 +10,7 @@ action=$1
 git_url=$2
 shift 2
 next=$1
-if [ ${next:0:1} != '-' ]; then
+if [ -n "$next" ] && [ ${next:0:1} != '-' ]; then
   target_dir=$git_url
   git_url=$1
   shift

--- a/types/github.sh
+++ b/types/github.sh
@@ -1,5 +1,10 @@
 # TODO some flag for git:// urls
 
+if [ -z "$git_call" ]; then
+  git_call=". $BORK_SOURCE_DIR/types/git.sh"
+  is_compiled && git_call="git"
+fi
+
 action=$1
 repo=$2
 shift 2
@@ -7,13 +12,33 @@ shift 2
 case $action in
   desc)
     echo "front-end for git type, uses github urls"
+    echo "passes arguments to git type"
     echo "> ok github mattly/bork"
-    echo "--branch=gh-pages        (specify branch or tag)"
+    echo "> ok github ~/code/bork mattly/bork"
+    echo "--ssh                    (clones via ssh instead of https)"
     ;;
+
   compile)
     include_assertion git $BORK_SOURCE_DIR/types/git.sh
     ;;
-  *)
-    . $BORK_SOURCE_DIR/types/git.sh $action "https://github.com/$(echo $repo).git" $*
+
+  status|install|upgrade)
+    next=$1
+    target_dir=
+    if [ -n "$next" ] && [ ${next:0:1} != '-' ]; then
+      target_dir="$repo"
+      repo=$1
+      shift
+    fi
+    args="$*"
+    if [ -n  "$(arguments get ssh $*)" ]; then
+      url="git@github.com:$(echo $repo).git"
+      args=$(echo "$args" | sed -E 's|--ssh||')
+    else
+      url="https://github.com/$(echo $repo).git"
+    fi
+    eval "$git_call $action $target_dir $url $args"
     ;;
+
+  *) return 1 ;;
 esac


### PR DESCRIPTION
Modifies both the git and github types to accept an explicit target directory as the second argument. Also provides an `--ssh` option for github to create `git@github.com:name/repo.git` style urls.

```
ok git ~/code/work/enterprise-project git@someserver.com:enterprise.git
ok github ~/code/bork mattly/bork --ssh
```