### PR TITLE
Add new Atom/apm type

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -110,6 +110,8 @@ from a recent version of bork, organized a bit:
                  > npm grunt-cli
             pip: asserts presence of packages installed via pip
                  > pip pygments
+            apm: asserts the presence of an atom package
+                 > apm docblockr
 ```
 
 #### MacOS X specific

--- a/types/apm.sh
+++ b/types/apm.sh
@@ -1,0 +1,25 @@
+# TODO tests - because it ain't code without tests
+# TODO --version - support for status, install, update
+
+action=$1
+pkgname=$2
+shift 2
+
+case $action in
+  desc)
+    echo "asserts the presence of an atom package"
+    echo "> apm docblockr"
+    ;;
+  status)
+    needs_exec "apm" || return $STATUS_FAILED_PRECONDITION
+    pkgs=$(bake apm ls --installed -b| # list all installed packages
+      sed 's/@[0-9\.]*//g')       # remove version pattern (@0.1.6)
+    if ! str_matches "$pkgs" "^$pkgname$"; then
+      return $STATUS_MISSING
+    fi
+    return 0
+    ;;
+  install)
+    bake apm install "$pkgname"
+    ;;
+esac


### PR DESCRIPTION
This PR adds a new type for Atom's package manager: `apm`.

I have no idea how to write a proper test case for this, so I'd appreciate if someone else could help out.

