### PR TITLE
Fix inaccurate listing of global NPM modules

### DIFF
--- a/types/npm.sh
+++ b/types/npm.sh
@@ -14,7 +14,8 @@ case $action in
     ;;
   status)
     needs_exec "npm" || return $STATUS_FAILED_PRECONDITION
-    pkgs=$(bake npm ls -g --depth 0 --parseable)
+    pkgs=$(bake npm ls -g --parseable |
+      grep "lib\/node_modules\/[-0-9A-Za-z\.-]*$")
     if ! str_matches "$pkgs" "\/$pkgname$"; then
       return $STATUS_MISSING
     fi


### PR DESCRIPTION
I noticed that `npm ls -g --depth 0 --parseable` doesn't respect the `depth` argument anymore and now also lists sub modules that are in use by the global ones:

```shell
❯  ~  npm ls -g --depth 0 --parseable
/Users/jonas/.npm-packages/lib
/Users/jonas/.npm-packages/lib/node_modules/bower
/Users/jonas/.npm-packages/lib/node_modules/diff-so-fancy
/Users/jonas/.npm-packages/lib/node_modules/electron-prebuilt
/Users/jonas/.npm-packages/lib/node_modules/electron-prebuilt/node_modules/electron-download
/Users/jonas/.npm-packages/lib/node_modules/electron-prebuilt/node_modules/debug
/Users/jonas/.npm-packages/lib/node_modules/electron-prebuilt/node_modules/ms
```

Here's an example that shows the incorrect behaviour. Since ms is just a sub module of electron-prebuild it shouldn't actually pass the assert check, but currently does:

```shell
❯  ~  bork do ok npm ms
ok: npm ms
```

That's why I adjusted the command that parses said modules into the `$pkgs` variable:

```shell
❯  ~  npm ls -g --parseable | grep "lib\/node_modules\/[0-9A-Za-z\.-]*$"
/Users/jonas/.npm-packages/lib/node_modules/bower
/Users/jonas/.npm-packages/lib/node_modules/diff-so-fancy
/Users/jonas/.npm-packages/lib/node_modules/electron-prebuilt
/Users/jonas/.npm-packages/lib/node_modules/grunt
/Users/jonas/.npm-packages/lib/node_modules/grunt-cli
/Users/jonas/.npm-packages/lib/node_modules/gulp
/Users/jonas/.npm-packages/lib/node_modules/hubot
/Users/jonas/.npm-packages/lib/node_modules/init.js
/Users/jonas/.npm-packages/lib/node_modules/json
/Users/jonas/.npm-packages/lib/node_modules/npm
/Users/jonas/.npm-packages/lib/node_modules/prettydiff
/Users/jonas/.npm-packages/lib/node_modules/prettyjson
/Users/jonas/.npm-packages/lib/node_modules/tlstools
/Users/jonas/.npm-packages/lib/node_modules/updatr
```
