### PR TITLE
single-quote arguments that would be expanded by eval

### DIFF
--- a/lib/declarations/ok.sh
+++ b/lib/declarations/ok.sh
@@ -64,7 +64,7 @@ ok () {
   argstr=$*
   quoted_argstr=
   while [ -n "$1" ]; do
-    quoted_argstr=$(echo "$quoted_argstr \"$1\"")
+    quoted_argstr=$(echo "$quoted_argstr '$1'")
     shift
   done
   case $operation in


### PR DESCRIPTION
I'm trying to create a new assertion type for appending a line to a file (e.g. ~/.profile) if it isn't already present. Here's an example invocation:

``` bash
ok lineinfile 'if which rbenv > /dev/null; then eval "$(rbenv init -)"; fi' ${HOME}/.profile
```

I won't bore you with the implementation details unless requested, but the above results in errors like ...
```
/usr/local/Cellar/bork/0.10.0/lib/helpers/bake.sh: line 1: PATH="/usr/local/var/rbenv/shims:${PATH}": No such file or directory
```
... presumably because the `$(rbenv init -)` part is being expanded somewhere along the way. It appears that's happening in the `ok` function, where args are re-quoted with double-quotes [and then subsequently eval'ed](https://github.com/mattly/bork/blob/789b0d26e2d128e0ab196578982b1c767ff328f5/lib/declarations/ok.sh#L74). 

Re-quoting `quoted_argstr` with single-quotes seems to fix the issue for me, and does not break any tests, but admittedly I may be missing some obvious way to escape the input to avoid the problem in the first place. 