### PR TITLE
Fix pip deprecation warning Add environment variable to force legacy listing

### DIFF
--- a/types/pip.sh
+++ b/types/pip.sh
@@ -13,7 +13,7 @@ case $action in
     ;;
   status)
     needs_exec "pip" || return $STATUS_FAILED_PRECONDITION
-    pkgs=$(bake pip list)
+    pkgs=$(PIP_FORMAT=legacy bake pip list)
     if ! str_matches "$pkgs" "^$name"; then
       return $STATUS_MISSING
     fi


### PR DESCRIPTION
pip in version 9.0.0 introduced a new listing type for `pip list` (see https://github.com/pypa/pip/pull/3654 and https://pip.pypa.io/en/stable/news/) which generates a default deprecation warning if no preference is set:

```
$ bork do ok pip
DEPRECATION: The default format will switch to columns in the future. You can use --format=legacy (or define a list_format in your pip.conf) to disable this warning.
ok: pip
```

This PR fixes said issue by passing the `PIP_FORMAT=legacy` variable to `bake`