### PR TITLE
Add support for Atom Beta (apm-beta)

### DIFF
--- a/types/apm.sh
+++ b/types/apm.sh
@@ -5,14 +5,20 @@ action=$1
 pkgname=$2
 shift 2
 
+if needs_exec "apm"; then
+  bin="apm"
+elif needs_exec "apm-beta"; then
+  bin="apm-beta"
+fi
+
 case $action in
   desc)
     echo "asserts the presence of an atom package"
     echo "> apm docblockr"
     ;;
   status)
-    needs_exec "apm" || return $STATUS_FAILED_PRECONDITION
-    pkgs=$(bake apm ls --installed -b| # list all installed packages
+    needs_exec "${bin}" || return $STATUS_FAILED_PRECONDITION
+    pkgs=$(bake ${bin} ls --installed -b| # list all installed packages
       sed 's/@[0-9\.]*//g')       # remove version pattern (@0.1.6)
     if ! str_matches "$pkgs" "^$pkgname$"; then
       return $STATUS_MISSING
@@ -20,6 +26,6 @@ case $action in
     return 0
     ;;
   install)
-    bake apm install "$pkgname"
+    bake ${bin} install "$pkgname"
     ;;
 esac

--- a/types/apm.sh
+++ b/types/apm.sh
@@ -5,9 +5,9 @@ action=$1
 pkgname=$2
 shift 2
 
-if needs_exec "apm"; then
+if hash "apm" 2>/dev/null; then
   bin="apm"
-elif needs_exec "apm-beta"; then
+elif hash "apm-beta" 2>/dev/null; then
   bin="apm-beta"
 fi
 


### PR DESCRIPTION
When using the [`atom-beta`](https://github.com/caskroom/homebrew-versions/blob/master/Casks/atom-beta.rb) brew package, the supplied `apm` command line helper is called `apm-beta` instead of `apm`.

This PR trys to figure out which binary exists in the atom type before running the actual apm commands. 

Not sure if that's the best way to solve this, let me know if you have any concerns.