### PR TITLE
Remove an element from an array correctly

### DIFF
--- a/lib/helpers/bag.sh
+++ b/lib/helpers/bag.sh
@@ -24,7 +24,7 @@ bag () {
   case "$action" in
     init) eval "$varname=( )" ;;
     push) eval "$varname[$length]=\"$1\"" ;;
-    pop) eval "unset $varname[$last]=" ;;
+    pop) eval "unset $varname[$last]" ;;
     read)
       [ "$length" -gt 0 ] && echo $(eval "echo \${$varname[$last]}") ;;
     size) echo $length ;;


### PR DESCRIPTION
bork doesn't work on bash 4.4.12 on Arch Linux because of syntax error:

```
$ bats test
...
 ✗ bag: pop removes top item from stack
   (from function `bag' in file lib/helpers/bag.sh, line 27,
    in test file test/help-bag.bats, line 40)
     `bag pop foo' failed
   /media/sf_bork/lib/helpers/bag.sh: 27 行: unset: `foo[1]=': 有効な識別子ではありません
...
```

This PR fix it.