### PR TITLE
Fix tests

### DIFF
--- a/lib/helpers/bag.sh
+++ b/lib/helpers/bag.sh
@@ -24,7 +24,7 @@ bag () {
   case "$action" in
     init) eval "$varname=( )" ;;
     push) eval "$varname[$length]=\"$1\"" ;;
-    pop) eval "unset $varname[$last]=" ;;
+    pop) eval "unset $varname[$last]" ;;
     read)
       [ "$length" -gt 0 ] && echo $(eval "echo \${$varname[$last]}") ;;
     size) echo $length ;;

--- a/test/declare-ok.bats
+++ b/test/declare-ok.bats
@@ -8,24 +8,24 @@ BORK_SCRIPT_DIR="$BORK_SOURCE_DIR/test"
 @test "ok: checks against core types" {
   run ok directory foo
   [ "$status" -eq 0 ]
-  [ "$BORK_SOURCE_DIR/types/directory.sh foo" = $output ]
+  [[ "$BORK_SOURCE_DIR/types/directory.sh foo" == $output ]]
 }
 
 @test "ok: checks against stdlib_types" {
   run ok brew foo
   [ "$status" -eq 0 ]
-  [ "$BORK_SOURCE_DIR/types/brew.sh foo" = $output ]
+  [[ "$BORK_SOURCE_DIR/types/brew.sh foo" == $output ]]
 }
 
 @test "ok: checks against local scripts" {
   run ok fixtures/custom.sh foo
   [ "$status" -eq 0 ]
-  [ "$BORK_SCRIPT_DIR/fixtures/custom.sh foo" = $output ]
+  [[ "$BORK_SCRIPT_DIR/fixtures/custom.sh foo" == $output ]]
 }
 
 @test "ok: checks against registered types" {
   register fixtures/custom.sh
   run ok custom foo
   [ "$status" -eq 0 ]
-  [ "$BORK_SCRIPT_DIR/fixtures/custom.sh foo" = $output ]
+  [[ "$BORK_SCRIPT_DIR/fixtures/custom.sh foo" == $output ]]
 }

--- a/test/help-http.bats
+++ b/test/help-http.bats
@@ -8,7 +8,7 @@
     respond_to "curl -sI \"https://foo.com\"" "cat $fixtures/http-head-curl.txt"
     run http_head_cmd "$url"
     [ "$status" -eq 0 ]
-    [ 'curl -sI "https://foo.com"' = $output ]
+    [[ 'curl -sI "https://foo.com"' == $output ]]
 }
 
 @test "http_header: extracting a header value" {
@@ -22,5 +22,5 @@
     target="/boo/baz"
     run http_get_cmd "$url" "$target"
     [ "$status" -eq 0 ]
-    [ "curl -so \"$target\" \"$url\" &> /dev/null" = $output ]
+    [[ "curl -so \"$target\" \"$url\" &> /dev/null" == $output ]]
 }

--- a/test/type-brew-tap.bats
+++ b/test/type-brew-tap.bats
@@ -46,8 +46,8 @@ setup () {
     run brew-tap install homebrew/science --pin
     [ "$status" -eq 0 ]
     run baked_output
-    [ "brew tap homebrew/science" = ${lines[0]} ]
-    [ "brew tap-pin homebrew/science" = ${lines[1]} ]
+    [[ "brew tap homebrew/science" == ${lines[0]} ]]
+    [[ "brew tap-pin homebrew/science" == ${lines[1]} ]]
 }
 
 @test "brew-tap upgrade with pin adds pin" {

--- a/test/type-file.bats
+++ b/test/type-file.bats
@@ -25,8 +25,8 @@ setup () {
   run file status wrongfile Readme.md
   [ "$status" -eq $STATUS_CONFLICT_UPGRADE ]
   expected="expected sum: $readsum"
-  [ "${lines[0]}" = $expected ]
-  [ "${lines[1]}" = "received sum: 123456" ]
+  [[ ${lines[0]} == $expected ]]
+  [[ ${lines[1]} == "received sum: 123456" ]]
 }
 
 @test "file status: returns OK when all is well" {
@@ -141,4 +141,3 @@ is_compiled () { [ -n "$is_compiled" ]; }
   expected=$(echo $expected)
   [[ "${lines[1]}" = $expected ]]
 }
-

--- a/test/type-git.bats
+++ b/test/type-git.bats
@@ -103,34 +103,33 @@ git_status_handler ()   { echo "$git_status"; }
   run git install $repo
   [ "$status" -eq 0 ]
   run baked_output
-  [ "mkdir -p bork" = ${lines[0]} ]
-  [ "git clone -b master $repo bork" = ${lines[1]} ]
+  [[ "mkdir -p bork" == ${lines[0]} ]]
+  [[ "git clone -b master $repo bork" == ${lines[1]} ]]
 }
 
 @test "git install: with target argument, performs clone" {
   run git install /Users/mattly/code/bork $repo
   [ "$status" -eq 0 ]
   run baked_output
-  [ "mkdir -p /Users/mattly/code/bork" = ${lines[0]} ]
-  [ "git clone -b master $repo /Users/mattly/code/bork" = ${lines[1]} ]
+  [[ "mkdir -p /Users/mattly/code/bork" == ${lines[0]} ]]
+  [[ "git clone -b master $repo /Users/mattly/code/bork" == ${lines[1]} ]]
 }
 
 @test "git install: uses specified branch" {
   run git install $repo --branch=experimental
   [ "$status" -eq 0 ]
   run baked_output
-  [ "mkdir -p bork" = ${lines[0]} ]
-  [ "git clone -b experimental $repo bork" = ${lines[1]} ]
+  [[ "mkdir -p bork" == ${lines[0]} ]]
+  [[ "git clone -b experimental $repo bork" == ${lines[1]} ]]
 }
 
 @test "git upgrade: merges to new ref, echoes changelog" {
   run git upgrade $repo
   [ "$status" -eq 0 ]
   run baked_output
-  [ "cd bork" = ${lines[0]} ]
-  [ "git reset --hard" = ${lines[1]} ]
-  [ "git pull" = ${lines[2]} ]
-  [ "git checkout master" = ${lines[3]} ]
-  [ "git log HEAD@{2}.." = ${lines[4]} ]
+  [[ "cd bork" == ${lines[0]} ]]
+  [[ "git reset --hard" == ${lines[1]} ]]
+  [[ "git pull" == ${lines[2]} ]]
+  [[ "git checkout master" == ${lines[3]} ]]
+  [[ "git log HEAD@{2}.." == ${lines[4]} ]]
 }
-

--- a/test/type-github.bats
+++ b/test/type-github.bats
@@ -28,9 +28,5 @@ git_call="intercept_git"
   bag init compiled_types
   run github compile foo/bar
   [ "$status" -eq 0 ]
-  n=0
-  for line in $gitfn; do
-    [ "${lines[n]}" = $line ]
-    n=$(( n + 1 ))
-  done
+  [[ ${output} == "${gitfn}" ]]
 }

--- a/test/type-symlink.bats
+++ b/test/type-symlink.bats
@@ -55,8 +55,7 @@ make_links () {
   run symlink install .README $sourcefile
   [ "$status" -eq 0 ]
   run baked_output
-  [ "ln -sf $sourcefile .README" = ${lines[0]} ]
+  [[ "ln -sf $sourcefile .README" == ${lines[0]} ]]
   [ -h .README ]
-  [ "$sourcefile" = $(readlink .README) ]
+  [[ ${sourcefile} == $(readlink .README) ]]
 }
-

--- a/test/type-user.bats
+++ b/test/type-user.bats
@@ -67,9 +67,9 @@ setup () {
   [ "$status" -eq 0 ]
   run baked_output
   [ "${#lines[*]}" -eq 3 ]
-  [ "${lines[0]}" = $users_query ]
-  [ "${lines[1]}" = "chsh -s /bin/zsh existant" ]
-  [ "${lines[2]}" = $groups_query ]
+  [[ ${lines[0]} == $users_query ]]
+  [[ ${lines[1]} == "chsh -s /bin/zsh existant" ]]
+  [[ ${lines[2]} == $groups_query ]]
 }
 
 # --- with group argument ------------------------------------
@@ -120,8 +120,8 @@ setup () {
   [ "$status" -eq 0 ]
   run baked_output
   [ "${#lines[*]}" -eq 4 ]
-  [ "${lines[0]}" = $users_query ]
-  [ "${lines[1]}" = $groups_query ]
-  [ "${lines[2]}" = "adduser existant foo" ]
-  [ "${lines[3]}" = "adduser existant bar" ]
+  [[ ${lines[0]} == $users_query ]]
+  [[ ${lines[1]} == $groups_query ]]
+  [[ ${lines[2]} == "adduser existant foo" ]]
+  [[ ${lines[3]} == "adduser existant bar" ]]
 }


### PR DESCRIPTION
- use `[[` extended test command as it does no word splitting or glob
  expansion so it's safer to use, especially when variable values
  contain spaces
- `bag pop` was using invalid syntax for unset

Fixes #99