### PR TITLE
directory: add support for setting ownership and mode

### DIFF
--- a/test/type-directories.bats
+++ b/test/type-directories.bats
@@ -40,6 +40,5 @@ mkdirs () {
   run directory install foo
   [ "$status" -eq 0 ]
   run baked_output
-  [ "${lines[0]}" = "mkdir -p foo" ]
+  [ "${lines[0]}" = "install -C -d foo" ]
 }
-

--- a/test/type-directory-perms.bats
+++ b/test/type-directory-perms.bats
@@ -4,7 +4,7 @@
 directory () { . $BORK_SOURCE_DIR/types/directory.sh $*; }
 
 setup() {
-  respond_to "stat --printf %U:%G:%a foo" "printf '%s:%s:%s' user users 755"
+  respond_to "stat --printf %U\n%G\n%a foo" "printf '%s\n%s\n%s' user users 755"
 }
 
 @test "directory: status returns MISMATCH_UPGRADE when target directory has incorrect owner" {

--- a/test/type-directory-perms.bats
+++ b/test/type-directory-perms.bats
@@ -4,7 +4,7 @@
 directory () { . $BORK_SOURCE_DIR/types/directory.sh $*; }
 
 setup() {
-  respond_to "stat --printf %U\n%G\n%a foo" "printf '%s\n%s\n%s' user users 755"
+  respond_to "stat --printf %U\\\n%G\\\n%a foo" "printf '%s\n%s\n%s' user users 755"
 }
 
 @test "directory: status returns MISMATCH_UPGRADE when target directory has incorrect owner" {

--- a/test/type-directory-perms.bats
+++ b/test/type-directory-perms.bats
@@ -37,6 +37,7 @@ setup() {
   run directory install foo --owner=bork
   (( status == 0 ))
   run baked_output
+  [[ ${lines[-1]} =~ ^sudo\ install ]]
   [[ ${lines[-1]} =~ '-o bork' ]]
 }
 
@@ -44,6 +45,7 @@ setup() {
   run directory install foo --group=bork
   (( status == 0 ))
   run baked_output
+  [[ ${lines[-1]} =~ ^sudo\ install ]]
   [[ ${lines[-1]} =~ '-g bork' ]]
 }
 
@@ -51,5 +53,6 @@ setup() {
   run directory install foo --mode=700
   (( status == 0 ))
   run baked_output
+  [[ ${lines[-1]} =~ ^install ]]
   [[ ${lines[-1]} =~ '-m 700' ]]
 }

--- a/test/type-directory-perms.bats
+++ b/test/type-directory-perms.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+
+. test/helpers.sh
+directory () { . $BORK_SOURCE_DIR/types/directory.sh $*; }
+
+setup() {
+  respond_to "stat --printf %U:%G:%a foo" "printf '%s:%s:%s' user users 755"
+}
+
+@test "directory: status returns MISMATCH_UPGRADE when target directory has incorrect owner" {
+  run directory status foo --owner=bork
+  (( status == STATUS_MISMATCH_UPGRADE ))
+  [[ ${lines[0]} == 'expected owner: bork' ]]
+  [[ ${lines[1]} == 'received owner: user' ]]
+}
+
+@test "directory: status returns MISMATCH_UPGRADE when target directory has incorrect group" {
+  run directory status foo --group=bork
+  (( status == STATUS_MISMATCH_UPGRADE ))
+  [[ ${lines[0]} == 'expected group: bork' ]]
+  [[ ${lines[1]} == 'received group: users' ]]
+}
+
+@test "directory: status returns MISMATCH_UPGRADE when target directory has incorrect mode" {
+  run directory status foo --mode=700
+  (( status == STATUS_MISMATCH_UPGRADE ))
+  [[ ${lines[0]} == 'expected mode: 700' ]]
+  [[ ${lines[1]} == 'received mode: 755' ]]
+}
+
+@test "directory: status returns OK when everything matches" {
+  run directory status foo --owner=user --group=users --mode=755
+  (( status == STATUS_OK ))
+}
+
+@test "directory: install sets owner for directory" {
+  run directory install foo --owner=bork
+  (( status == 0 ))
+  run baked_output
+  [[ ${lines[-1]} =~ '-o bork' ]]
+}
+
+@test "directory: install sets group for directory" {
+  run directory install foo --group=bork
+  (( status == 0 ))
+  run baked_output
+  [[ ${lines[-1]} =~ '-g bork' ]]
+}
+
+@test "directory: install sets mode for directory" {
+  run directory install foo --mode=700
+  (( status == 0 ))
+  run baked_output
+  [[ ${lines[-1]} =~ '-m 700' ]]
+}

--- a/types/directory.sh
+++ b/types/directory.sh
@@ -60,11 +60,12 @@ case "$action" in
     ;;
 
   install|upgrade)
-    inst_opts=( -C -d )
-    [[ -z ${owner} ]] || inst_opts+=( -o "${owner}" )
-    [[ -z ${group} ]] || inst_opts+=( -g "${group}" )
-    [[ -z ${mode} ]] || inst_opts+=( -m "${mode}" )
-    bake install "${inst_opts[@]}" "${dir}"
+    inst_cmd=( install -C -d )
+    [[ -z ${owner} && -z ${group} ]] || inst_cmd=( sudo "${inst_cmd[@]}" )
+    [[ -z ${owner} ]] || inst_cmd+=( -o "${owner}" )
+    [[ -z ${group} ]] || inst_cmd+=( -g "${group}" )
+    [[ -z ${mode} ]] || inst_cmd+=( -m "${mode}" )
+    bake "${inst_cmd[@]}" "${dir}"
     ;;
 
   *) return 1 ;;

--- a/types/directory.sh
+++ b/types/directory.sh
@@ -28,7 +28,7 @@ case "$action" in
 
     mismatch=false
     if [[ -n ${owner} || -n ${group} || -n ${mode} ]]; then
-      readarray -t dir_stat < <(bake stat --printf '%U\n%G\n%a' "${dir}")
+      readarray -t dir_stat < <(bake stat --printf '%U\\n%G\\n%a' "${dir}")
 
       if [[ -n ${owner} && ${dir_stat[0]} != ${owner} ]]; then
         printf '%s owner: %s\n' \

--- a/types/directory.sh
+++ b/types/directory.sh
@@ -28,7 +28,7 @@ case "$action" in
 
     mismatch=false
     if [[ -n ${owner} || -n ${group} || -n ${mode} ]]; then
-      readarray -d : -t dir_stat < <(bake stat --printf '%U:%G:%a' "${dir}")
+      readarray -t dir_stat < <(bake stat --printf '%U\n%G\n%a' "${dir}")
 
       if [[ -n ${owner} && ${dir_stat[0]} != ${owner} ]]; then
         printf '%s owner: %s\n' \

--- a/types/directory.sh
+++ b/types/directory.sh
@@ -4,20 +4,68 @@ action=$1
 dir=$2
 shift 2
 
+owner=$(arguments get owner $*)
+group=$(arguments get group $*)
+mode=$(arguments get mode $*)
+
 case "$action" in
   desc)
-    echo "asserts presence of a directory"
-    echo "* directories ~/.ssh"
+    printf '%s\n' \
+      'asserts presence of a directory' \
+      '* directory path [options]' \
+      '--owner=user-name' \
+      '--group=group-name' \
+      '--mode=mode' \
+      '> directory ~/.ssh --mode=700'
     ;;
 
   status)
-    [ ! -e "$dir" ] && return $STATUS_MISSING
-    [ -d "$dir" ] && return $STATUS_OK
-    echo "target exists as non-directory"
-    return $STATUS_CONFLICT_CLOBBER
+    bake [ -e "${dir}" ] || return $STATUS_MISSING
+    bake [ -d "${dir}" ] || {
+      echo "target exists as non-directory"
+      return $STATUS_CONFLICT_CLOBBER
+    }
+
+    mismatch=false
+    if [[ -n ${owner} || -n ${group} || -n ${mode} ]]; then
+      readarray -d : -t dir_stat < <(bake stat --printf '%U:%G:%a' "${dir}")
+
+      if [[ -n ${owner} && ${dir_stat[0]} != ${owner} ]]; then
+        printf '%s owner: %s\n' \
+          'expected' "${owner}" \
+          'received' "${dir_stat[0]}"
+        mismatch=true
+      fi
+
+      if [[ -n ${group} && ${dir_stat[1]} != ${group} ]]; then
+        printf '%s group: %s\n' \
+          'expected' "${group}" \
+          'received' "${dir_stat[1]}"
+        mismatch=true
+      fi
+
+      if [[ -n ${mode} && ${dir_stat[2]} != ${mode} ]]; then
+        printf '%s mode: %s\n' \
+          'expected' "${mode}" \
+          'received' "${dir_stat[2]}"
+        mismatch=true
+      fi
+    fi
+
+    if ${mismatch}; then
+      return "${STATUS_MISMATCH_UPGRADE}"
+    fi
+
+    return "${STATUS_OK}"
     ;;
 
-  install) bake mkdir -p $dir ;;
+  install|upgrade)
+    inst_opts=( -C -d )
+    [[ -z ${owner} ]] || inst_opts+=( -o "${owner}" )
+    [[ -z ${group} ]] || inst_opts+=( -g "${group}" )
+    [[ -z ${mode} ]] || inst_opts+=( -m "${mode}" )
+    bake install "${inst_opts[@]}" "${dir}"
+    ;;
 
   *) return 1 ;;
 esac


### PR DESCRIPTION
Use `install` executable instead of `mkdir` as it already implements all
the required features, including idempotency. Like `mkdir -p` it also
creates parent directories as necessary.

Closes #101