### PR TITLE
Use `npm install` to update, because `upgrade` is weird.

### DIFF
--- a/test/type-npm.bats
+++ b/test/type-npm.bats
@@ -39,5 +39,5 @@ setup () {
   run npm upgrade foo
   [ "$status" -eq 0 ]
   run baked_output
-  [ "${lines[0]}" = "npm -g update foo" ]
+  [ "${lines[0]}" = "npm -g install foo" ]
 }

--- a/types/npm.sh
+++ b/types/npm.sh
@@ -31,7 +31,7 @@ case $action in
     ;;
 
   upgrade)
-    bake npm -g update "$pkgname"
+    bake npm -g install "$pkgname"
     ;;
 
   *) return 1 ;;


### PR DESCRIPTION
Apparently `npm upgrade` can install versions "newer" than what is considered "latest". Yeah, your guess is as good as mine. Then again, this is from people who think JavaScript is a Neat Idea.

Closes #69 