### PR TITLE
set the call to the git type to the correct function name

### DIFF
--- a/types/github.sh
+++ b/types/github.sh
@@ -2,7 +2,7 @@
 
 if [ -z "$git_call" ]; then
   git_call=". $BORK_SOURCE_DIR/types/git.sh"
-  is_compiled && git_call="git"
+  is_compiled && git_call="type_git"
 fi
 
 action=$1


### PR DESCRIPTION
Sadly, I'm really not sure how to test this without getting a completely different test harness up and going.

Closes #90 /cc @edrex 