### PR TITLE
sketch on fixing the quote problem

### DIFF
--- a/lib/helpers/bake.sh
+++ b/lib/helpers/bake.sh
@@ -1,1 +1,13 @@
-bake () { eval "$*"; }
+bake () {
+  C=''
+  for i in "$@"; do
+      case "$i" in
+          *\'*)
+              i=`printf "%s" "$i" | sed "s/'/'\"'\"'/g"`
+              ;;
+          *) : ;;
+      esac
+      C="$C '$i'"
+  done
+  eval "$C"
+}

--- a/lib/helpers/status_codes.sh
+++ b/lib/helpers/status_codes.sh
@@ -30,8 +30,7 @@ _status_for () {
     $STATUS_FAILED_ARGUMENTS) echo "error (failed arguments)" ;;
     $STATUS_FAILED_ARGUMENT_PRECONDITION) echo "error (failed argument precondition)" ;;
     $STATUS_FAILED_PRECONDITION) echo "error (failed precondition)" ;;
-    $STATUS_UNSUPPORTED_PLATFORM) echo "error (unsupported platform)" ;;
+    $STATUS_UNSUPPORTED_PLATFORM) echo "error (unsupported platform $baking_platform)" ;;
     *)    echo "unknown status: $1" ;;
   esac
 }
-

--- a/lib/helpers/system.sh
+++ b/lib/helpers/system.sh
@@ -12,7 +12,7 @@ needs_exec () {
   [ -z "$2" ] && running_status=0 || running_status=$2
 
   # was seeing some weirdness on this where $1 would have carraige returns sometimes, so it's quoted.
-  path=$(bake "which $1")
+  path=$(bake which "$1")
 
   if [ "$?" -gt 0 ]; then
     echo "missing required exec: $1"
@@ -44,4 +44,3 @@ baking_platform_is () {
   [ "$baking_platform" = $1 ]
   return $?
 }
-

--- a/test/help-bake.bats
+++ b/test/help-bake.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+
+. test/helpers.sh
+
+@test "bake will escape its arguments before eval" {
+  run bake ls -la "foo bar"
+  run baked_output
+  [ "$output" = " 'ls' '-la' 'foo bar'" ]
+}

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -10,18 +10,24 @@ p () {
 md5c=$(md5cmd $platform)
 baking_responder=
 baking_file=$(mktemp -t bork_test.XXXXXX)
-bake () {
-  echo "$*" >> $baking_file;
-  key=$(echo "$*" | eval $md5c)
-  handler=$(bag get responders $key)
-  p "looking up $* at $key, found $handler"
-  if [ -n "$handler" ]; then
-    eval $handler
+NEW_BAKE_FN=$(cat <<HERE
+  bake ()
+  $(declare -f bake | tail -n +2 | sed -E 's|eval "\$C"||' | sed -e 's|^}$||')
+  echo "\$C" >> $baking_file
+  key=\$(echo "\$C" | eval \$md5c)
+  handler=\$(bag get responders \$key)
+  p "looking up \$C at \$key, found \$handler"
+  if [ -n "\$handler" ]; then
+    eval \$handler
   else
-    baking_responder $*
+    baking_responder \$C
   fi
   return
 }
+HERE
+)
+eval "$NEW_BAKE_FN"
+
 # overwrite this in your tests
 baking_responder () { :; }
 
@@ -36,4 +42,3 @@ respond_to () {
   bag set responders "$key" "$2"
 }
 return_with () { return $1; }
-


### PR DESCRIPTION
**DO NOT MERGE**. Actually I disabled merges that don't pass CI, and this sure as hell won't.

So this is a stab at #87 by @frdmn whereby bake isn't handling quoted arguments well. And, I knew I was doing something hacky with bake, but I really had no idea just how hacky. Short of reworking all the types to turn `bake ls -la $dir` into `bake "ls -la $dir"`, this seems to be the next best thing: escaping quotes on every item in the argument list to bake.

The problem is `bake` is so central to everything, all for the sake of having nice, stubbable tests, whereby I could test the logic for f.e. `apt` on my mac, or `brew` on a linux CI server, without resorting to VMs and whatnot. So now pretty much all of the tests are going to fail and need to have their `respond_to` and `baking_output` stuff changed.

Since I'm not even sure this will have the desired effect without breaking everything (it seems to work ok locally) I'd like to get some eyes on it before going to the effort of updating all the tests.