### PR TITLE
Updates symlinking to use original dotfile name

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -71,9 +71,9 @@ ok brew git                                   # presence and updatedness of Home
 ok directory $HOME/code                       # presence of the ~/code directory
 ok github $HOME/code/dotfiles mattly/dotfiles # presence, drift of git repository in ~/code/dotfiles
 cd $HOME
-for file in $HOME/code/dotfiles/configs/*
+for file in $HOME/code/dotfiles/configs/.[!.]*
 do                                            # for each file in ~/code/dotfiles/configs,
-  ok symlink ".$(basename $file)" $file       # presense of a symlink to file in ~ with a leading dot
+  ok symlink "$(basename $file)" $file       # presense of a symlink to file in ~ with a leading dot
 done
 ```
 


### PR DESCRIPTION
Suggestion to symlink using original .dotfile form when looping through each config file

`.[!.]*` matches all dot files except `.` and files whose name begins with `..`
