### PR TITLE
Bash if statement should end in `fi`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -275,7 +275,7 @@ ok brew fish
 if did_install; then
   sudo echo "/usr/local/bin/fish" >> /etc/shells
   chsh -s /usr/local/bin/fish
-end
+fi
 ```
 There are four functions to help you take further actions on change:
 


### PR DESCRIPTION
There's an `if` statement in the `Readme` that is closed with `end` rather than `fi`. This PR fixes that thing.